### PR TITLE
Reduce docker image size and bump fluentd version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,18 +7,14 @@ ENV BUILDDEPS="sudo make gcc g++ libc-dev ruby-dev libffi-dev"
 
 RUN apt-get update \
     && apt-get upgrade -y \
-    && apt-get install -y --no-install-recommends \
-    $BUILDDEPS
-
-RUN echo 'gem: --no-document' >> /etc/gemrc \
+    && apt-get install -y --no-install-recommends $BUILDDEPS \ 
+    && echo 'gem: --no-document' >> /etc/gemrc \
     && gem install fluent-plugin-systemd -v 0.3.1 \
     && gem install fluent-plugin-papertrail -v 0.2.5 \
     && gem install fluent-plugin-loggly-syslog -v 0.0.2 \
     && gem install fluent-plugin-kubernetes_metadata_input -v 0.21.11 \
-    && gem install fluent-plugin-kubernetes_metadata_filter -v 2.0.0
-
-RUN SUDO_FORCE_REMOVE=yes \
-    apt-get purge -y --auto-remove \
+    && gem install fluent-plugin-kubernetes_metadata_filter -v 2.0.0 \
+    && SUDO_FORCE_REMOVE=yes apt-get purge -y --auto-remove \
                   -o APT::AutoRemove::RecommendsImportant=false \
                   $BUILDDEPS \
     && rm -rf /var/lib/apt/lists/* \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM fluent/fluentd:v1.1.1-debian
+FROM fluent/fluentd:v1.2-debian
 
 USER root
 WORKDIR /home/fluent
@@ -14,7 +14,7 @@ RUN apt-get update \
     && gem install fluent-plugin-loggly-syslog -v 0.0.2 \
     && gem install fluent-plugin-rewrite-tag-filter -v 2.0.2 \
     && gem install fluent-plugin-kubernetes_metadata_input -v 0.21.11 \
-    && gem install fluent-plugin-kubernetes_metadata_filter -v 2.0.0 \
+    && gem install fluent-plugin-kubernetes_metadata_filter -v 2.1.2 \
     && SUDO_FORCE_REMOVE=yes apt-get purge -y --auto-remove \
                   -o APT::AutoRemove::RecommendsImportant=false \
                   $BUILDDEPS \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update \
     && gem install fluent-plugin-systemd -v 0.3.1 \
     && gem install fluent-plugin-papertrail -v 0.2.5 \
     && gem install fluent-plugin-loggly-syslog -v 0.0.2 \
+    && gem install fluent-plugin-rewrite-tag-filter -v 2.0.2 \
     && gem install fluent-plugin-kubernetes_metadata_input -v 0.21.11 \
     && gem install fluent-plugin-kubernetes_metadata_filter -v 2.0.0 \
     && SUDO_FORCE_REMOVE=yes apt-get purge -y --auto-remove \


### PR DESCRIPTION
Reduce docker layer sizes

Combining the various RUN layers for install / compile / delete into one
helps reduce the docker layer size. This change reduces the final size of
the image from 329MB to 184MB.

--

Added tag rewrite plugin to allow better output routing functionality. This can come in handy if there is a need to redirect logs as per namespaces to various papertrail endpoints.