### PR TITLE
Api update 1.17

### DIFF
--- a/kubernetes/fluentd-daemonset-papertrail.yaml
+++ b/kubernetes/fluentd-daemonset-papertrail.yaml
@@ -8,6 +8,9 @@ metadata:
     version: v1
     kubernetes.io/cluster-service: "true"
 spec:
+  selector:
+    matchLabels:
+        k8s-app: fluentd-papertrail
   updateStrategy:
     type: RollingUpdate
   template:

--- a/kubernetes/fluentd-daemonset-papertrail.yaml
+++ b/kubernetes/fluentd-daemonset-papertrail.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: fluentd-papertrail

--- a/kubernetes/fluentd-daemonset-papertrail.yaml
+++ b/kubernetes/fluentd-daemonset-papertrail.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-        k8s-app: fluentd-papertrail
+      k8s-app: fluentd-papertrail
   updateStrategy:
     type: RollingUpdate
   template:


### PR DESCRIPTION
Support for extensions/v1beta1 was removed in v1.16, see: https://github.com/kubernetes/kubernetes/issues/84782

Updated API version and added a missing selector to the deployment. Tested with Kubernetes 1.17.